### PR TITLE
fix: added 100mb video warning

### DIFF
--- a/src/app/transcription/components/TranscriptionForm.tsx
+++ b/src/app/transcription/components/TranscriptionForm.tsx
@@ -46,6 +46,13 @@ export default function TranscriptionForm({ onTranscriptionComplete, taskId }: T
       return
     }
 
+    // Validación de tamaño máximo (100MB)
+    const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB en bytes
+    if (selectedFile.size > MAX_FILE_SIZE) {
+      setError('El archivo es demasiado grande. El tamaño máximo permitido es 100MB.')
+      return
+    }
+
     setFile(selectedFile)
     setFileName(selectedFile.name)
     setError('')


### PR DESCRIPTION
Se añadió que el usuario no puede subir un video superior a los 100 mb. Para comprobar que todo funcione bien:
1. Probar con un video inferior a 100 mb. El video debe cargar y transcribirse bien.
2. Probar con un video superior a 100 mb. Debe lanzar un error indicando que el video supera los 100 mb.