### PR TITLE
Feat: Control Strategy Selector working properly with new mutations in backend

### DIFF
--- a/src/app/tasks/[task_id]/risk_analysis/page.tsx
+++ b/src/app/tasks/[task_id]/risk_analysis/page.tsx
@@ -1,5 +1,4 @@
-// src/app/tasks/[task_id]/risk_analysis/page.tsx
-import TaskExecution from "@/app/tasks/components/TaskExecution";
+import TaskExecutionClientWrapper from "@/app/tasks/components/TaskExecutionClientWrapper";
 import { notFound } from "next/navigation";
 import { validateTaskAccess } from "@/services/tasks";
 import { cookies } from "next/headers";
@@ -142,7 +141,7 @@ export default async function RiskAnalysisPage({
   console.log("Task comments to be passed:", taskData?.comments);
 
   return (
-    <TaskExecution
+    <TaskExecutionClientWrapper
       taskId={task_id}
       multimediaData={multimediaData}
       taskComments={taskData?.comments || null}

--- a/src/app/tasks/components/ControlStrategySelector.tsx
+++ b/src/app/tasks/components/ControlStrategySelector.tsx
@@ -5,30 +5,34 @@ import { Search, ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { gql, useMutation, useQuery } from '@apollo/client'
 import client from '@/lib/apollo-client'
+import { useControlStrategies } from "./TaskExecutionClientWrapper";
 
 const FIND_ALL_CONTROL_STRATEGIES = gql`
   query FindAllControlStrategies {
     findAllControlStrategies {
       id
-      taskId
       title
     }
   }
 `;
 
-const UPDATE_CONTROL_STRATEGY = gql`
-  mutation UpdateControlStrategy($input: UpdateControlStrategyInput!) {
-    updateControlStrategy(input: $input) {
+const ASSIGN_CONTROL_STRATEGY = gql`
+  mutation assignControlStrategy($input: AssignControlStrategyInput!) {
+    assignControlStrategy(input: $input) {
       id
-      taskId
       title
+      controlStrategyIds
     }
   }
 `;
 
-const DELETE_CONTROL_STRATEGY = gql`
-  mutation DeleteControlStrategy($deleteControlStrategyId: Int!) {
-    deleteControlStrategy(id: $deleteControlStrategyId)
+const UNASSIGN_CONTROL_STRATEGY = gql`
+  mutation unassignControlStrategy($input: UnassignControlStrategyInput!) {
+    unassignControlStrategy(input: $input) {
+      id
+      title
+      controlStrategyIds
+    }
   }
 `;
 
@@ -51,7 +55,7 @@ export default function ControlStrategySelector({
   taskId,
   existingStrategies = []
 }: ControlStrategySelectorProps) {
-  const [selectedStrategies, setSelectedStrategies] = useState<ControlStrategy[]>([]);
+  const { selectedStrategies, setSelectedStrategies } = useControlStrategies();
   const [searchQuery, setSearchQuery] = useState("");
   const [error, setError] = useState<string>("");
 
@@ -66,19 +70,19 @@ export default function ControlStrategySelector({
   });
 
   // Mutation para actualizar estrategias
-  const [updateStrategy] = useMutation(UPDATE_CONTROL_STRATEGY, {
+  const [assignControlStrategy] = useMutation(ASSIGN_CONTROL_STRATEGY, {
     client,
     onError: (error) => {
-      console.error('Error updating strategy:', error);
+      console.error('Error assigning strategy:', error);
       setError('Error al agregar la estrategia. Por favor, intenta de nuevo.');
     }
   });
 
   // Mutation para eliminar estrategias
-  const [deleteStrategy] = useMutation(DELETE_CONTROL_STRATEGY, {
+  const [unassignControlStrategy] = useMutation(UNASSIGN_CONTROL_STRATEGY, {
     client,
     onError: (error) => {
-      console.error('Error deleting strategy:', error);
+      console.error('Error unassigning strategy:', error);
       setError('Error al eliminar la estrategia. Por favor, intenta de nuevo.');
     }
   });
@@ -88,7 +92,7 @@ export default function ControlStrategySelector({
     if (existingStrategies?.length > 0) {
       setSelectedStrategies(existingStrategies);
     }
-  }, [existingStrategies]);
+  }, [existingStrategies, setSelectedStrategies]);
 
   // Obtener estrategias únicas (sin duplicados por título)
   const uniqueStrategies = useMemo(() => {
@@ -110,36 +114,41 @@ export default function ControlStrategySelector({
     if (isSelected) {
       // Si ya está seleccionada, la quitamos
       const strategyToRemove = selectedStrategies.find(s => s.title === strategy.title);
-      if (strategyToRemove?.taskId === taskId) {
+      
         try {
-          await deleteStrategy({
+          await unassignControlStrategy({
             variables: {
-              deleteControlStrategyId: Number(strategyToRemove.id)
+              input: {
+                taskId: Number(taskId),
+                controlStrategyId: Number(strategyToRemove.id)
+              }
             }
           });
-          setSelectedStrategies(prev => prev.filter(s => s.title !== strategy.title));
         } catch (error) {
-          console.error('Error in delete operation:', error);
+          console.error('Error in unassign operation:', error);
           setError('Error al eliminar la estrategia. Por favor, intenta de nuevo.');
         }
-      }
+      setSelectedStrategies(prev => prev.filter(s => s.title !== strategy.title));
     } else {
-      // Si no está seleccionada, creamos una nueva con el taskId actual
       try {
-        const result = await updateStrategy({
+        const result = await assignControlStrategy({
           variables: {
             input: {
               taskId,
-              title: strategy.title
+              controlStrategyId: Number(strategy.id)
             }
           }
         });
         
-        if (result.data?.updateControlStrategy) {
-          setSelectedStrategies(prev => [...prev, result.data.updateControlStrategy]);
+        if (result.data?.assignControlStrategy) {
+          setSelectedStrategies(prev => [...prev, {
+            id: strategy.id,
+            title: strategy.title,
+            taskId: taskId
+          }]);
         }
       } catch (error) {
-        console.error('Error in update operation:', error);
+        console.error('Error in assign operation:', error);
         setError('Error al agregar la estrategia. Por favor, intenta de nuevo.');
       }
     }

--- a/src/app/tasks/components/TaskExecution.tsx
+++ b/src/app/tasks/components/TaskExecution.tsx
@@ -10,12 +10,12 @@ import ControlStrategySelector from "@/app/tasks/components/ControlStrategySelec
 import { gql, useQuery, useMutation } from "@apollo/client";
 import client from "@/lib/apollo-client";
 import Image from "next/image";
+import { useControlStrategies } from "./TaskExecutionClientWrapper";
 
-const FIND_ALL_CONTROL_STRATEGIES = gql`
-  query FindAllControlStrategies {
-    findAllControlStrategies {
+const FIND_CONTROL_STRATEGIES_BY_TASK = gql`
+  query FindControlStrategiesByTask($taskId: Int!) {
+    findControlStrategiesByTask(taskId: $taskId) {
       id
-      taskId
       title
     }
   }
@@ -26,6 +26,16 @@ const UPDATE_TASK = gql`
     updateTask(input: $input) {
       id
       comments
+    }
+  }
+`;
+
+const UNASSIGN_CONTROL_STRATEGY = gql`
+  mutation unassignControlStrategy($input: UnassignControlStrategyInput!) {
+    unassignControlStrategy(input: $input) {
+      id
+      title
+      controlStrategyIds
     }
   }
 `;
@@ -60,7 +70,7 @@ export default function TaskExecution({
   const [uploadedVideo, setUploadedVideo] = useState<MultimediaData | null>(null);
   const [uploadedPhotos, setUploadedPhotos] = useState<MultimediaData[]>([]);
   const [showStrategySelector, setShowStrategySelector] = useState(false);
-  const [selectedStrategies, setSelectedStrategies] = useState<ControlStrategy[]>([]);
+  const { selectedStrategies, setSelectedStrategies } = useControlStrategies();
   const [comments, setComments] = useState(taskComments || "");
   const [isEditingComments, setIsEditingComments] = useState(false);
   const [isSavingComments, setIsSavingComments] = useState(false);
@@ -76,12 +86,18 @@ export default function TaskExecution({
   const hasExistingPhotos = totalPhotos > 0;
 
   // Obtener todas las estrategias de control
-  const { data: strategiesData, loading: loadingStrategies } = useQuery(FIND_ALL_CONTROL_STRATEGIES, {
+  const { loading: loadingStrategies } = useQuery(FIND_CONTROL_STRATEGIES_BY_TASK, {
     client,
+    variables: { taskId: taskId ? Number(taskId) : 0 },
     skip: !taskId,
     onError: (error) => {
       console.error("Error fetching strategies:", error);
     },
+    onCompleted: (data) => {
+      if (data?.findControlStrategiesByTask) {
+        setSelectedStrategies(data.findControlStrategiesByTask);
+      }
+    }
   });
 
   const [updateTask] = useMutation(UPDATE_TASK, {
@@ -101,6 +117,14 @@ export default function TaskExecution({
     },
   });
 
+  const [unassignControlStrategy] = useMutation(UNASSIGN_CONTROL_STRATEGY, {
+    client,
+    onError: (error) => {
+      console.error("Error unassigning control strategy:", error);
+      setError("Error al eliminar la estrategia. Por favor, intente de nuevo.");
+    },
+  });
+
   // Inicializar transcriptionResult con los datos almacenados o con los existentes en BD
   useEffect(() => {
     if (existingVideo) {
@@ -116,16 +140,6 @@ export default function TaskExecution({
       }
     }
   }, [taskId, existingVideo]);
-
-  // Filtrar estrategias por taskId
-  useEffect(() => {
-    if (strategiesData?.findAllControlStrategies && taskId) {
-      const taskStrategies = strategiesData.findAllControlStrategies.filter(
-        (strategy: ControlStrategy) => strategy.taskId === Number(taskId)
-      );
-      setSelectedStrategies(taskStrategies);
-    }
-  }, [strategiesData, taskId]);
 
   // Sincronizar comentarios si cambian desde props
   useEffect(() => {
@@ -171,6 +185,26 @@ export default function TaskExecution({
   const handleStrategySelection = (strategies: ControlStrategy[]) => {
     setSelectedStrategies(strategies);
     setShowStrategySelector(false);
+  };
+
+  const handleStrategyRemoval = async (strategy: ControlStrategy) => {
+    try {
+      // If the strategy has a taskId matching the current task, unassign it via API
+      await unassignControlStrategy({
+        variables: {
+          input: {
+            taskId: Number(taskId),
+            controlStrategyId: Number(strategy.id)
+          }
+        }
+      });
+      
+      // Remove from UI regardless of API call
+      setSelectedStrategies((prev) => prev.filter((s) => s.id !== strategy.id));
+    } catch (error) {
+      console.error("Error removing strategy:", error);
+      setError("Error al eliminar la estrategia. Por favor, intente de nuevo.");
+    }
   };
 
   const handleSaveComments = async () => {
@@ -435,11 +469,7 @@ export default function TaskExecution({
                   >
                     {strategy.title}
                     <button
-                      onClick={() =>
-                        setSelectedStrategies((prev) =>
-                          prev.filter((s) => s.id !== strategy.id)
-                        )
-                      }
+                      onClick={() => handleStrategyRemoval(strategy)}
                       className="hover:bg-teal-800 rounded-full p-0.5"
                     >
                       <X className="h-4 w-4" />

--- a/src/app/tasks/components/TaskExecutionClientWrapper.tsx
+++ b/src/app/tasks/components/TaskExecutionClientWrapper.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { createContext, useState, useContext, ReactNode } from 'react';
+import TaskExecution from "./TaskExecution";
+
+interface ControlStrategy {
+  id: string;
+  taskId?: number | null;
+  title: string;
+}
+
+interface ControlStrategiesContextType {
+  selectedStrategies: ControlStrategy[];
+  setSelectedStrategies: (strategies: ControlStrategy[]) => void;
+}
+
+const ControlStrategiesContext = createContext<ControlStrategiesContextType | undefined>(undefined);
+
+export function useControlStrategies() {
+  const context = useContext(ControlStrategiesContext);
+  if (context === undefined) {
+    throw new Error('useControlStrategies must be used within a ControlStrategiesProvider');
+  }
+  return context;
+}
+
+function ControlStrategiesProvider({ children, initialStrategies = [] }: { children: ReactNode, initialStrategies?: ControlStrategy[] }) {
+  const [selectedStrategies, setSelectedStrategies] = useState<ControlStrategy[]>(initialStrategies);
+
+  return (
+    <ControlStrategiesContext.Provider value={{ selectedStrategies, setSelectedStrategies }}>
+      {children}
+    </ControlStrategiesContext.Provider>
+  );
+}
+
+interface MultimediaData {
+  id: number;
+  taskId: number;
+  photoUrl: string | null;
+  videoUrl: string | null;
+  audioTranscription: string | null;
+}
+
+interface TaskExecutionClientWrapperProps {
+  taskId: string;
+  multimediaData: MultimediaData[];
+  taskComments: string | null;
+}
+
+export default function TaskExecutionClientWrapper({
+  taskId,
+  multimediaData,
+  taskComments
+}: TaskExecutionClientWrapperProps) {
+  return (
+    <ControlStrategiesProvider>
+      <TaskExecution
+        taskId={taskId}
+        multimediaData={multimediaData}
+        taskComments={taskComments}
+      />
+    </ControlStrategiesProvider>
+  );
+}

--- a/src/app/tasks/components/TaskIntro.tsx
+++ b/src/app/tasks/components/TaskIntro.tsx
@@ -81,7 +81,9 @@ export default function TaskIntro({ taskId, taskTitle }: { taskId?: string, task
 
         <div className="p-4 w-full mt-8 md:mt-auto pb-8">
           <Button
-            onClick={() => router.push(`/tasks/${taskId || 'id'}/risk_analysis`)}
+            onClick={() => {
+              window.location.href = `/tasks/${taskId || 'id'}/risk_analysis`;
+            }}
             className="w-full md:max-w-xs md:mx-auto md:block bg-teal-700 hover:bg-teal-800 text-white rounded-md font-normal text-lg mb-4 flex items-center justify-center h-12"
           >
             Comenzar Análisis de Riesgo

--- a/src/app/tasks/context/ControlStrategiesContext.tsx
+++ b/src/app/tasks/context/ControlStrategiesContext.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, useState, useContext, ReactNode } from 'react';
+
+interface ControlStrategy {
+  id: string;
+  taskId?: number | null;
+  title: string;
+}
+
+interface ControlStrategiesContextType {
+  selectedStrategies: ControlStrategy[];
+  setSelectedStrategies: (strategies: ControlStrategy[]) => void;
+}
+
+const ControlStrategiesContext = createContext<ControlStrategiesContextType | undefined>(undefined);
+
+export function ControlStrategiesProvider({ children, initialStrategies = [] }: { children: ReactNode, initialStrategies?: ControlStrategy[] }) {
+  const [selectedStrategies, setSelectedStrategies] = useState<ControlStrategy[]>(initialStrategies);
+
+  return (
+    <ControlStrategiesContext.Provider value={{ selectedStrategies, setSelectedStrategies }}>
+      {children}
+    </ControlStrategiesContext.Provider>
+  );
+}
+
+export function useControlStrategies() {
+  const context = useContext(ControlStrategiesContext);
+  if (context === undefined) {
+    throw new Error('useControlStrategies must be used within a ControlStrategiesProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
Se actualiza `src/app/tasks/components/TaskExecution.tsx` y `src/app/tasks/components/ControlStrategySelector.tsx` para usar las mutaciones` assignControlStrategy(taskId, controlStrategyId)` `unassignControlStrategy(taskId, controlStrategyId)` del backend