### PR TITLE
fix/changed limit video size to 70

### DIFF
--- a/src/app/transcription/components/TranscriptionForm.tsx
+++ b/src/app/transcription/components/TranscriptionForm.tsx
@@ -47,10 +47,10 @@ export default function TranscriptionForm({ onTranscriptionComplete, taskId }: T
       return
     }
 
-    // Validación de tamaño máximo (100MB)
-    const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB en bytes
+    // Validación de tamaño máximo (70MB)
+    const MAX_FILE_SIZE = 70 * 1024 * 1024; // 70MB en bytes
     if (selectedFile.size > MAX_FILE_SIZE) {
-      setError('El archivo es demasiado grande. El tamaño máximo permitido es 100MB.')
+      setError('El archivo es demasiado grande. El tamaño máximo permitido es 70MB.')
       return
     }
 


### PR DESCRIPTION
El límite para subir un video antes era de 100 MB, ahora es de 70 MB. Para probar que funciona bien:
1. Subir un video bajo 70 MB (ideal que sea lo más cercano a 70 para probar lo más caso borde que se pueda)
2. Subir un video sobre 70 MB (ideal que sea bajo 100 MB para asegurarse que el límite anterior ya no es tomado en cuenta)